### PR TITLE
Do not hardcode Xcode path in project.pbxproj

### DIFF
--- a/src/core/kext/10.6/PCKeyboardHack.xcodeproj/project.pbxproj
+++ b/src/core/kext/10.6/PCKeyboardHack.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx10.6;
-				USER_HEADER_SEARCH_PATHS = "include ../common /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.6.sdk/System/Library/Frameworks/Kernel.framework/Headers/IOKit/**";
+				USER_HEADER_SEARCH_PATHS = "include ../common";
 				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;

--- a/src/core/kext/10.6/include/IOHIDConsumer.h
+++ b/src/core/kext/10.6/include/IOHIDConsumer.h
@@ -31,9 +31,9 @@
 // HID system includes.
 #include <IOKit/hidsystem/IOHIDDescriptorParser.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
-#include "IOHIKeyboard.h"
+#include <IOKit/hidsystem/IOHIKeyboard.h>
 #include "IOHIDKeyboard.h"
-#include "IOHIDEventService.h"
+#include <IOKit/hidevent/IOHIDEventService.h>
 
 // extra includes.
 #include <libkern/OSByteOrder.h>

--- a/src/core/kext/10.6/include/IOHIDFamilyPrivate.h
+++ b/src/core/kext/10.6/include/IOHIDFamilyPrivate.h
@@ -23,8 +23,8 @@
 #ifndef _IOKIT_HID_IOHIDFAMILYPRIVATE_H
 #define _IOKIT_HID_IOHIDFAMILYPRIVATE_H
 
-#include "IOHIDKeys.h"
-#include "IOHIDDevice.h"
+#include <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/hid/IOHIDDevice.h>
 
 __BEGIN_DECLS
 

--- a/src/core/kext/10.6/include/IOHIDKeyboard.h
+++ b/src/core/kext/10.6/include/IOHIDKeyboard.h
@@ -26,11 +26,11 @@
 #define _IOKIT_HID_IOHIDKEYBOARD_H
 
 #include <IOKit/hidsystem/IOHIDTypes.h>
-#include "IOHIKeyboard.h"
-#include "IOHIDDevice.h"
+#include <IOKit/hidsystem/IOHIKeyboard.h>
+#include <IOKit/hid/IOHIDDevice.h>
 #include "IOHIDConsumer.h"
-#include "IOHIDElement.h"
-#include "IOHIDEventService.h"
+#include <IOKit/hid/IOHIDElement.h>
+#include <IOKit/hidevent/IOHIDEventService.h>
 #include "IOHIDFamilyPrivate.h"
 
 enum {

--- a/src/core/kext/10.7/PCKeyboardHack.xcodeproj/project.pbxproj
+++ b/src/core/kext/10.7/PCKeyboardHack.xcodeproj/project.pbxproj
@@ -263,7 +263,7 @@
 				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				SDKROOT = macosx;
-				USER_HEADER_SEARCH_PATHS = "include ../common /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk/System/Library/Frameworks/Kernel.framework/Headers/IOKit/**";
+				USER_HEADER_SEARCH_PATHS = "include ../common";
 				VALID_ARCHS = "i386 x86_64";
 				WRAPPER_EXTENSION = kext;
 			};

--- a/src/core/kext/10.7/include/IOHIDConsumer.h
+++ b/src/core/kext/10.7/include/IOHIDConsumer.h
@@ -31,9 +31,9 @@
 // HID system includes.
 #include <IOKit/hidsystem/IOHIDDescriptorParser.h>
 #include <IOKit/hidsystem/IOHIDShared.h>
-#include "IOHIKeyboard.h"
+#include <IOKit/hidsystem/IOHIKeyboard.h>
 #include "IOHIDKeyboard.h"
-#include "IOHIDEventService.h"
+#include <IOKit/hidevent/IOHIDEventService.h>
 
 // extra includes.
 #include <libkern/OSByteOrder.h>

--- a/src/core/kext/10.7/include/IOHIDFamilyPrivate.h
+++ b/src/core/kext/10.7/include/IOHIDFamilyPrivate.h
@@ -23,8 +23,8 @@
 #ifndef _IOKIT_HID_IOHIDFAMILYPRIVATE_H
 #define _IOKIT_HID_IOHIDFAMILYPRIVATE_H
 
-#include "IOHIDKeys.h"
-#include "IOHIDDevice.h"
+#include <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/hid/IOHIDDevice.h>
 
 __BEGIN_DECLS
 

--- a/src/core/kext/10.7/include/IOHIDKeyboard.h
+++ b/src/core/kext/10.7/include/IOHIDKeyboard.h
@@ -26,11 +26,11 @@
 #define _IOKIT_HID_IOHIDKEYBOARD_H
 
 #include <IOKit/hidsystem/IOHIDTypes.h>
-#include "IOHIKeyboard.h"
-#include "IOHIDDevice.h"
+#include <IOKit/hidsystem/IOHIKeyboard.h>
+#include <IOKit/hid/IOHIDDevice.h>
 #include "IOHIDConsumer.h"
-#include "IOHIDElement.h"
-#include "IOHIDEventService.h"
+#include <IOKit/hid/IOHIDElement.h>
+#include <IOKit/hidevent/IOHIDEventService.h>
 #include "IOHIDFamilyPrivate.h"
 
 enum {


### PR DESCRIPTION
Makes it possible to build project with non-standart Xcode (ie Xcode-123.app)
