### PR TITLE
Allow PCKeyboardHack to (Temporarily) Work in Mountain Lion

### DIFF
--- a/files/scripts/kext.sh
+++ b/files/scripts/kext.sh
@@ -11,6 +11,9 @@ case "${uname%%.*}" in
     11)
         kextfile="$basedir/PCKeyboardHack.10.7.kext"
         ;;
+    12)
+        kextfile="$basedir/PCKeyboardHack.10.7.kext" # Temporary fix to allow 10.8 to use 10.7's kext
+        ;;
 esac
 
 if [ "x$kextfile" == 'x' ]; then


### PR DESCRIPTION
Hey,

I'm not sure if you would want to use this, but I thought I'd submit it just in case. I mentioned this fix in issue #8 ("Doesn't work in Mountain Lion?"). This quick hack would allow Mountain Lion to use PCKeyboardHack's 10.7 kext until 10.8's source code is released.

Hope this helps!
-Josh
